### PR TITLE
Change float conversion to int for cases where only ints make sense

### DIFF
--- a/sixpack/models.py
+++ b/sixpack/models.py
@@ -161,7 +161,7 @@ class Experiment(object):
 
         redis_results = pipe.execute()
         for idx, k in enumerate(keys):
-            stats[k] = float(redis_results[idx])
+            stats[k] = int(redis_results[idx])
 
         return stats
 
@@ -589,7 +589,7 @@ class Alternative(object):
 
         redis_results = pipe.execute()
         for idx, k in enumerate(keys):
-            stats[k] = float(redis_results[idx])
+            stats[k] = int(redis_results[idx])
 
         return stats
 


### PR DESCRIPTION
The number of participants and conversions are always ints. We looked into when this change was made and could not find any explanation why this was done. (https://github.com/seatgeek/sixpack/commit/d9e5bbc4fd2cdd5cfdcb5440be1918fab8e9c833)

This is problematic when working with strong-typed languages such as go that expect correct numbers to be returned and writing float when it will never have a value that can be a non-int it does not seem to make sense to convert it to a float.
