### PR TITLE
Add option to record forced experiment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,8 @@ Arguments
 
 In this example, red will always be returned. This is used for testing only, and no participation will be recorded.
 
+``record_force`` (optional) for use with ``force``, participation will be recorded.
+
 ``traffic_fraction`` (optional) Sixpack allows for limiting experiments to a subset of traffic. You can pass the percentage of traffic you'd like to expose the test to as a decimal number here. (``?traffic_fraction=0.10`` for 10%)
 
 

--- a/sixpack/api.py
+++ b/sixpack/api.py
@@ -4,6 +4,7 @@ from config import CONFIG as cfg
 
 def participate(experiment, alternatives, client_id,
     force=None,
+    record_force=False,
     traffic_fraction=None,
     prefetch=False,
     datetime=None,
@@ -14,6 +15,11 @@ def participate(experiment, alternatives, client_id,
     alt = None
     if force and force in alternatives:
         alt = Alternative(force, exp, redis=redis)
+
+        if record_force:
+            client = Client(client_id, redis=redis)
+            alt.record_participation(client, datetime)
+
     elif not cfg.get('enabled', True):
         alt = exp.control
     elif exp.winner is not None:

--- a/sixpack/server.py
+++ b/sixpack/server.py
@@ -150,6 +150,7 @@ class Sixpack(object):
         alts = request.args.getlist('alternatives')
         experiment_name = request.args.get('experiment')
         force = request.args.get('force')
+        record_force = request.args.get('record_force')
         client_id = request.args.get('client_id')
         traffic_fraction = request.args.get('traffic_fraction')
         if traffic_fraction is not None:
@@ -172,7 +173,8 @@ class Sixpack(object):
         else:
             try:
                 alt = participate(experiment_name, alts, client_id,
-                                  force=force, traffic_fraction=traffic_fraction,
+                                  force=force, record_force=record_force,
+                                  traffic_fraction=traffic_fraction,
                                   prefetch=prefetch, datetime=dt, redis=self.redis)
             except ValueError as e:
                 return json_error({'message': str(e)}, request, 400)


### PR DESCRIPTION
This PR re-implements @christophervalles's work in https://github.com/seatgeek/sixpack/pull/177 to add the ability to record forced experiments.

While I understand the initial intent of force was mainly for the ability to preview alternatives, adding this option is very useful for us for a number of reasons:
- There are some 'experiments' where we want to control the segmentation ourselves - enable an alternative for staff, or users from a certain geographic area.
- Be able to use segmentation on the server when using a cache/CDN like Akamai, which can perform [segmentation for us in a cache-friendly manner](https://www.akamai.com/uk/en/solutions/products/web-performance/cloudlets/audience-segmentation.jsp) and still use sixpack to report conversions and results.
