### PR TITLE
Enable SIXPACK_CONFIG_REDIS_URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,9 @@ Next, create a Sixpack configuration. A configuration must be created for Sixpac
 
     redis_port: 6379                            # Redis port
     redis_host: localhost                       # Redis host
+    # redis_password: password                  # Optional redis password
+    # Alternatively the above can be set with redis_url which takes precedence
+    # redis_url:  'redis://h:password@localhost:6379'
     redis_prefix: sixpack                       # all Redis keys will be prefixed with this
     redis_db: 15                                # DB number in redis
 
@@ -58,6 +61,7 @@ Alternatively, as of version 1.1, all Sixpack configuration can be set by enviro
 * ``SIXPACK_CONFIG_REDIS_PORT``
 * ``SIXPACK_CONFIG_REDIS_HOST``
 * ``SIXPACK_CONFIG_REDIS_PASSWORD``
+* ``SIXPACK_CONFIG_REDIS_URL``
 * ``SIXPACK_CONFIG_REDIS_PREFIX``
 * ``SIXPACK_CONFIG_REDIS_DB``
 * ``SIXPACK_CONFIG_ROBOT_REGEX``
@@ -66,6 +70,8 @@ Alternatively, as of version 1.1, all Sixpack configuration can be set by enviro
 * ``SIXPACK_CONFIG_SECRET``
 * ``SIXPACK_METRICS``
 * ``STATSD_URL``
+
+``SIXPACK_CONFIG_REDIS_URL`` takes precedence over the indivudal port/host/password settings
 
 Using the API
 =============

--- a/sixpack/config.py
+++ b/sixpack/config.py
@@ -1,5 +1,6 @@
 import yaml
 import os
+import urlparse
 
 from utils import to_bool
 
@@ -16,6 +17,7 @@ else:
         'enabled': to_bool(os.environ.get('SIXPACK_CONFIG_ENABLED', 'True')),
         'redis_port': int(os.environ.get('SIXPACK_CONFIG_REDIS_PORT', '6379')),
         'redis_host': os.environ.get('SIXPACK_CONFIG_REDIS_HOST', "localhost"),
+        'redis_url': os.environ.get('SIXPACK_CONFIG_REDIS_URL', None),
         'redis_password': os.environ.get('SIXPACK_CONFIG_REDIS_PASSWORD', None),
         'redis_prefix': os.environ.get('SIXPACK_CONFIG_REDIS_PREFIX', "sxp"),
         'redis_socket_timeout': os.environ.get('SIXPACK_CONFIG_REDIS_SOCKET_TIMEOUT', None),
@@ -42,3 +44,11 @@ else:
             server,port = sentinel.split(":")
             sentinels.append([server, int(port)])
         CONFIG['redis_sentinels'] = sentinels
+
+    # redis_url or SIXPACK_CONFIG_REDIS_URL takes precedence
+    if CONFIG['redis_url']:
+      urlparse.uses_netloc.append("redis")
+      url = urlparse.urlparse(os.environ["SIXPACK_CONFIG_REDIS_URL"])
+      CONFIG["redis_host"] = url.hostname or 'localhost'
+      CONFIG["redis_port"] = url.port or 6379
+      CONFIG["redis_password"] = url.password


### PR DESCRIPTION
Redis has a URI scheme:

https://www.iana.org/assignments/uri-schemes/prov/redis

This implements a simple version to enable use eg on heroku with
REDIS_URL

Signed-off-by: Pris Nasrat <pnasrat@gmail.com>