### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'match'

### DIFF
--- a/sixpack/server.py
+++ b/sixpack/server.py
@@ -45,7 +45,7 @@ class CORSMiddleware(object):
     def __call__(self, environ, start_response):
 
         def get_origin(status, headers):
-            if self.origin == '*':
+            if self.origin == '*' or self.origin is None:
                 return self.origin
             origin = environ.get("HTTP_ORIGIN", "")
             return origin if self.origin_regexp.match(origin) else "null"


### PR DESCRIPTION
Fixes:
File "/var/www/sixpack/venv_sixpack/local/lib/python2.7/site-packages/sixpack/server.py",
 line 51, in get_origin
 return origin if self.origin_regexp.match(origin) else "null"
 AttributeError: 'NoneType' object has no attribute 'match'