### PR TITLE
Add excluded info to response

### DIFF
--- a/sixpack/server.py
+++ b/sixpack/server.py
@@ -199,7 +199,6 @@ class Sixpack(object):
         record_force = to_bool(request.args.get('record_force', 'false'))
         client_id = request.args.get('client_id')
         client = Client(client_id, redis=self.redis)
-        show_excluded = request.args.get('show_excluded') == 'true'
         traffic_fraction = request.args.get('traffic_fraction')
 
         if traffic_fraction is not None:
@@ -227,7 +226,7 @@ class Sixpack(object):
         except ValueError as e:
             return json_error({'message': str(e)}, request, 400)
 
-        excluded = bool(alt.experiment.is_client_excluded(client)) if show_excluded else "null"
+        excluded = bool(alt.experiment.is_client_excluded(client))
 
         resp = {
             'alternative': {

--- a/sixpack/server.py
+++ b/sixpack/server.py
@@ -198,6 +198,8 @@ class Sixpack(object):
         force = request.args.get('force')
         record_force = to_bool(request.args.get('record_force', 'false'))
         client_id = request.args.get('client_id')
+        client = Client(client_id, redis=self.redis)
+        show_excluded = request.args.get('show_excluded') == 'true'
         traffic_fraction = request.args.get('traffic_fraction')
 
         if traffic_fraction is not None:
@@ -225,6 +227,8 @@ class Sixpack(object):
         except ValueError as e:
             return json_error({'message': str(e)}, request, 400)
 
+        excluded = bool(alt.experiment.is_client_excluded(client)) if show_excluded else "null"
+
         resp = {
             'alternative': {
                 'name': alt.name
@@ -233,6 +237,7 @@ class Sixpack(object):
                 'name': alt.experiment.name,
             },
             'client_id': client_id,
+            'excluded': excluded,
             'status': 'ok'
         }
 

--- a/sixpack/test/server_test.py
+++ b/sixpack/test/server_test.py
@@ -65,19 +65,6 @@ class TestServer(unittest.TestCase):
         self.assertTrue('name' in data['experiment'])
         self.assertTrue('client_id' in data)
         self.assertTrue('status' in data)
-        self.assertEqual(data['excluded'], 'null')
-        self.assertEqual(data['status'], 'ok')
-
-    def test_ok_participate_with_excluded_parameter(self):
-        resp = self.client.get("/participate?experiment=dummy&client_id=foo&alternatives=one&alternatives=two&show_excluded=true")
-        data = json.loads(resp.data)
-        self.assertEqual(200, resp.status_code)
-        self.assertTrue('alternative' in data)
-        self.assertTrue('name' in data['alternative'])
-        self.assertTrue('experiment' in data)
-        self.assertTrue('name' in data['experiment'])
-        self.assertTrue('client_id' in data)
-        self.assertTrue('status' in data)
         self.assertTrue(data['excluded'] == False or data['excluded'] == True)
         self.assertEqual(data['status'], 'ok')
 

--- a/sixpack/test/server_test.py
+++ b/sixpack/test/server_test.py
@@ -65,6 +65,20 @@ class TestServer(unittest.TestCase):
         self.assertTrue('name' in data['experiment'])
         self.assertTrue('client_id' in data)
         self.assertTrue('status' in data)
+        self.assertEqual(data['excluded'], 'null')
+        self.assertEqual(data['status'], 'ok')
+
+    def test_ok_participate_with_excluded_parameter(self):
+        resp = self.client.get("/participate?experiment=dummy&client_id=foo&alternatives=one&alternatives=two&show_excluded=true")
+        data = json.loads(resp.data)
+        self.assertEqual(200, resp.status_code)
+        self.assertTrue('alternative' in data)
+        self.assertTrue('name' in data['alternative'])
+        self.assertTrue('experiment' in data)
+        self.assertTrue('name' in data['experiment'])
+        self.assertTrue('client_id' in data)
+        self.assertTrue('status' in data)
+        self.assertTrue(data['excluded'] == False or data['excluded'] == True)
         self.assertEqual(data['status'], 'ok')
 
     def test_participate_useragent_filter(self):


### PR DESCRIPTION
We need info about participation in experiment. Returning default alternative is not enough in our case. This PR introduces changes that allows to fetch such data.

Why?
Because we cannot establish if user has really participated in experiment or not - default alternative returned in that case is not enough.

What does this change introduce?
For participation endpoint, I added `excluded` response parameter to distinguish if user got into sixpack experiment

Example of response payload:
```
{
  'alternative': {
    'name': 'default'
  },
  'experiment': {
    'name': 'exp-1',
  },
  'client_id': '1234-5678-1234-5678',
  'excluded': true,
  'status': 'ok'
}
```